### PR TITLE
Added Variable Groups cmdlets

### DIFF
--- a/InSpark.InfrastructureAsCode/Public/Add-AzDoVariableGroupVariable.ps1
+++ b/InSpark.InfrastructureAsCode/Public/Add-AzDoVariableGroupVariable.ps1
@@ -1,0 +1,107 @@
+function Add-AzDoVariableGroupVariable {
+    <#
+    .SYNOPSIS
+        This script adds variables to variable groups in a given project.
+    .DESCRIPTION
+        This script adds variables to variable groups in a given project.
+        When used in a pipeline, you can use the pre defined CollectionUri, ProjectName and AccessToken (PAT) variables.
+    .EXAMPLE
+        $splat = @{
+            CollectionUri     = 'https://dev.azure.com/ChristianPiet0452/'
+            ProjectName       = 'Ditproject'
+            PAT = '*******************'
+            VariableGroupName = @('Group1', 'Group2')
+            Variables         = @{
+                test = @{
+                    value = 'test'
+                }
+                kaas = @{
+                    value = 'kaas'
+                }
+            }
+        }
+
+        Add-AzDoVariableGroupVariable @splat
+
+        This example creates a new Variable Group with a variable "test = test".
+
+    .EXAMPLE
+        $splat = @{
+            CollectionUri     = 'https://dev.azure.com/ChristianPiet0452/'
+            ProjectName       = 'Ditproject'
+            VariableGroupName = @('Group1', 'Group2')
+        }
+        Get-AzDoVariableGroup @splat | Add-AzDoVariableGroupVariable -Variables @{ test = @{ value = 'test' } }
+
+        This example creates a few new Variable Groups with a variable "test = test".
+    .OUTPUTS
+        PSObject
+    .NOTES
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        # Collection Uri of the organization
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [string]
+        $CollectionUri,
+
+        # PAT to authenticate with the organization
+        [Parameter()]
+        [string]
+        $PAT = $env:SYSTEM_ACCESSTOKEN,
+
+        # Project where the variable group has to be created
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [string]
+        $ProjectName,
+
+        # Name of the variable group
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [string[]]
+        $VariableGroupName,
+
+        # Variable names and values
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName, ValueFromPipeline)]
+        [hashtable]
+        $Variables
+    )
+    Process {
+        $groups = Get-AzDoVariableGroup -CollectionUri $CollectionUri -PAT $PAT -ProjectName $ProjectName
+        foreach ($name in $VariableGroupName) {
+            # Get the variable group based on it's name and match to ID for URI
+            $group = $groups | Where-Object { $_.VariableGroupName -eq $name }
+            # $group.Variables isn't a hashtable, so it needs to be converted and back to be able
+            $group.Variables = ($group.Variables | ConvertTo-Json | ConvertFrom-Json -AsHashtable)
+
+            $body = @{
+                variables = $Variables + $group.Variables
+                name      = $group.VariableGroupName
+            }
+
+            $params = @{
+                uri         = "$CollectionUri/$ProjectName/_apis/distributedtask/variablegroups/$($group.VariableGroupId)?api-version=7.1-preview.1"
+                Method      = 'PUT'
+                Headers     = @{Authorization = 'Basic ' + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":$($PAT)")) }
+                body        = $Body | ConvertTo-Json -Depth 99
+                ContentType = 'application/json'
+            }
+
+            if ($PSCmdlet.ShouldProcess($CollectionUri)) {
+
+                (Invoke-RestMethod @params) | ForEach-Object {
+                    [PSCustomObject]@{
+                        VariableGroupName = $_.name
+                        VariableGroupId   = $_.id
+                        Variables         = $_.variables
+                        CreatedOn         = $_.createdOn
+                        IsShared          = $_.isShared
+                        ProjectName       = $ProjectName
+                        CollectionURI     = $CollectionUri
+                    }
+                }
+            } else {
+                $body | Out-String
+            }
+        }
+    }
+}

--- a/InSpark.InfrastructureAsCode/Public/Get-AzDoVariableGroup.ps1
+++ b/InSpark.InfrastructureAsCode/Public/Get-AzDoVariableGroup.ps1
@@ -1,0 +1,84 @@
+function Get-AzDoVariableGroup {
+    <#
+    .SYNOPSIS
+        This script gets a variable group details in a given project.
+    .DESCRIPTION
+        This script gets a variable groups a given project.
+        When used in a pipeline, you can use the pre defined CollectionUri, ProjectName and AccessToken (PAT) variables.
+    .EXAMPLE
+        $params = @{
+            Collectionuri = 'https://dev.azure.com/weareinspark/'
+            PAT = '*******************'
+            ProjectName = 'Project 1'
+            VariableGroupName = 'VariableGroup1','VariableGroup2'
+        }
+        Get-AzDoVariableGroup @params
+
+        This example gets Variable Groups 'VariableGroup1' and 'VariableGroup2' .
+    .EXAMPLE
+        $params = @{
+            Collectionuri = 'https://dev.azure.com/weareinspark/'
+            PAT = '*******************'
+            ProjectName = 'Project 1'
+        }
+        Get-AzDoVariableGroup @params
+
+        This example gets all variable groups the user has access to within a project.
+    .OUTPUTS
+        PSObject
+    .NOTES
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        # Collection Uri of the organization
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [string]
+        $CollectionUri,
+
+        # PAT to authentice with the organization
+        [Parameter()]
+        [string]
+        $PAT = $env:SYSTEM_ACCESSTOKEN,
+
+        # Project where the variable group has to be created
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [string]
+        $ProjectName,
+
+        # Name of the variable group
+        [Parameter(ValueFromPipelineByPropertyName, ValueFromPipeline)]
+        [string[]]
+        $VariableGroupName
+    )
+    Process {
+        $params = @{
+            uri         = "$CollectionUri/$ProjectName/_apis/distributedtask/variablegroups?api-version=7.1-preview.2"
+            Method      = 'GET'
+            Headers     = @{Authorization = 'Basic ' + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(":$($PAT)")) }
+            body        = $Body | ConvertTo-Json -Depth 99
+            ContentType = 'application/json'
+        }
+
+        if ($PSCmdlet.ShouldProcess($CollectionUri)) {
+
+            $result = (Invoke-RestMethod @params).value | ForEach-Object {
+                [PSCustomObject]@{
+                    VariableGroupName = $_.name
+                    VariableGroupId   = $_.id
+                    Variables         = $_.variables
+                    CreatedOn         = $_.createdOn
+                    IsShared          = $_.isShared
+                    ProjectName       = $ProjectName
+                    CollectionURI     = $CollectionUri
+                }
+            }
+            if ($VariableGroupName) {
+                $result | Where-Object { $VariableGroupName -eq $_.VariableGroupName }
+            } else {
+                $result
+            }
+        } else {
+            $body | Out-String
+        }
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added `Add-AzDoVariableGroupVariable` and `Get-AzDoVariableGroup`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This gives users a different option than to used the GUI or the Azure CLI

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested it with my own organization and a PAT

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

```Powershell
Invoke-ScriptAnalyzer -Path /Users/christianpiet/Documents/InSpark/Git/InSpark/DNA/BRC.PS.InfrastructureAsCode/InSpark.InfrastructureAsCode/Public/Add-AzDoVariableGroupVariable.ps1 -CustomRulePath /Users/christianpiet/Documents/InSpark/Git/InSpark/DNA/BRC.PS.InfrastructureAsCode/tests/Indented.ScriptAnalyzerRules/Indented.ScriptAnalyzerRules.psd1

RuleName                            Severity     ScriptName Line  Message
--------                            --------     ---------- ----  -------
UseSyntacticallyCorrectExamples     Warning      Add-AzDoVa 1     Unable to determine parameter set used by example 1 for the
                                                 riableGrou       function Add-AzDoVariableGroupVariable
                                                 pVariable.
                                                 ps1
UseSyntacticallyCorrectExamples     Warning      Add-AzDoVa 1     Unable to determine parameter set used by example 2 for the
                                                 riableGrou       function Add-AzDoVariableGroupVariable
                                                 pVariable.
                                                 ps1
```
