### PR TITLE
feat: Add PipelineFolderPath parameter to New-AzDoPipeline

### DIFF
--- a/AzureDevOpsPowerShell/Public/Api/Pipelines/Pipelines/New-AzDoPipeline.ps1
+++ b/AzureDevOpsPowerShell/Public/Api/Pipelines/Pipelines/New-AzDoPipeline.ps1
@@ -48,6 +48,10 @@ function New-AzDoPipeline {
     [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
     $RepoName,
 
+    # Folder to put Azure Devops Pipeline in
+    [Parameter(ValueFromPipelineByPropertyName)]
+    $PipelineFolderPath = $null,
+
     # Path of the YAML-sourcecode in the Repository
     [Parameter(ValueFromPipelineByPropertyName)]
     [string]
@@ -70,7 +74,7 @@ function New-AzDoPipeline {
 
     $body = @{
       name          = $PipelineName
-      folder        = $null
+      folder        = $PipelineFolderPath
       configuration = @{
         type       = "yaml"
         path       = $Path


### PR DESCRIPTION
Add PipelineFolderPath parameter to be able to place a pipeline in a folder in azure devops to the module: New-AzDoPipeline

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add PipelineFolderPath parameter to be able to place a pipeline in a folder in azure devops to the module: New-AzDoPipeline

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
With the current implementation you are unable to pass in an azure pipelines folder path. (its hard coded to $null)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran the cmdlets against a devops project and created 2 pipelines one with a folderpath and one without

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

