### PR TITLE
fix: ✨ Add ManagementGroup parametersset  for WorkloadIdentityFederation

### DIFF
--- a/AzureDevOpsPowerShell/Public/Api/ServiceEndpoints/Endpoints/New-AzDoServiceConnection.ps1
+++ b/AzureDevOpsPowerShell/Public/Api/ServiceEndpoints/Endpoints/New-AzDoServiceConnection.ps1
@@ -102,11 +102,13 @@ function New-AzDoServiceConnection {
 
     # ID of the Management group.
     [Parameter(Mandatory, ValueFromPipelineByPropertyName, ParameterSetName = 'ManagementGroup')]
+    [Parameter(ValueFromPipelineByPropertyName, ParameterSetName = 'WorkloadIdentityFederation')]
     [string]
     $ManagementGroupId,
 
     # Name of the Management group.
     [Parameter(Mandatory, ValueFromPipelineByPropertyName, ParameterSetName = 'ManagementGroup')]
+    [Parameter(ValueFromPipelineByPropertyName, ParameterSetName = 'WorkloadIdentityFederation')]
     [string]
     $ManagementGroupName,
 


### PR DESCRIPTION
* Added `ManagementGroupId` and `ManagementGroupName` parameters to the `New-AzDoServiceConnection` function for the `WorkloadIdentityFederation` parameter set.
* This enhances the functionality by allowing management group details to be specified when creating service connections with Workload Identity Federation.

## Description
Fixes issue 

## Related Issue
https://github.com/WeAreInSpark/AzureDevOpsPowerShellAPI/issues/84

## Motivation and Context
Fixes issue of creating Service Connections on Management Group scope with Workload Identity Federation authentication

## How Has This Been Tested?
Yes, tested in production.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

